### PR TITLE
Fix Pydantic deprecation warnings and improve field naming

### DIFF
--- a/api/validation/models.py
+++ b/api/validation/models.py
@@ -1,0 +1,98 @@
+"""
+Pydantic models for JSON Placeholder API data validation.
+"""
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+
+
+class User(BaseModel):
+    """User model for JSON Placeholder API."""
+
+    id: int | None = None
+    name: str = Field(..., min_length=1)
+    username: str = Field(..., min_length=1)
+    email: str = Field(..., pattern=r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
+    address: dict = Field(...)
+    phone: str
+    website: str
+    company: dict
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class Post(BaseModel):
+    """Post model for JSON Placeholder API."""
+
+    id: int | None = None
+    user_id: int = Field(..., gt=0)
+    title: str = Field(..., min_length=1)
+    body: str = Field(..., min_length=1)
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True,
+        alias_generator=lambda field_name: "userId" if field_name == "user_id" else field_name,
+    )
+
+
+class Comment(BaseModel):
+    """Comment model for JSON Placeholder API."""
+
+    id: int | None = None
+    post_id: int = Field(..., gt=0)
+    name: str = Field(..., min_length=1)
+    email: str = Field(..., pattern=r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
+    body: str = Field(..., min_length=1)
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True,
+        alias_generator=lambda field_name: "postId" if field_name == "post_id" else field_name,
+    )
+
+
+class Todo(BaseModel):
+    """Todo model for JSON Placeholder API."""
+
+    id: int | None = None
+    user_id: int = Field(..., gt=0)
+    title: str = Field(..., min_length=1)
+    completed: bool
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True,
+        alias_generator=lambda field_name: "userId" if field_name == "user_id" else field_name,
+    )
+
+
+class Album(BaseModel):
+    """Album model for JSON Placeholder API."""
+
+    id: int | None = None
+    user_id: int = Field(..., gt=0)
+    title: str = Field(..., min_length=1)
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True,
+        alias_generator=lambda field_name: "userId" if field_name == "user_id" else field_name,
+    )
+
+
+class Photo(BaseModel):
+    """Photo model for JSON Placeholder API."""
+
+    id: int | None = None
+    album_id: int = Field(..., gt=0)
+    title: str = Field(..., min_length=1)
+    url: HttpUrl
+    thumbnail_url: HttpUrl
+
+    model_config = ConfigDict(
+        from_attributes=True,
+        populate_by_name=True,
+        alias_generator=lambda field_name: {"album_id": "albumId", "thumbnail_url": "thumbnailUrl"}.get(
+            field_name, field_name
+        ),
+    )


### PR DESCRIPTION
This PR includes the following changes:

1. Updates Pydantic models to use `ConfigDict` instead of class-based `Config` to fix deprecation warnings
2. Improves field naming to follow Python naming conventions (snake_case)
3. Implements proper field aliases to maintain compatibility with the JSON API format
4. Uses `populate_by_name=True` to allow both snake_case and camelCase field access

Note: There are some remaining linting issues in other files that will be addressed in a separate PR to keep the changes focused.